### PR TITLE
feat(signup-buttons): remove subscribe by sms, only show whatsapp

### DIFF
--- a/src/app/signup/signup-buttons.tsx
+++ b/src/app/signup/signup-buttons.tsx
@@ -40,17 +40,8 @@ export function SignUpButtons() {
           <button
             type="submit"
             aria-disabled={pending}
-            name="sms-button"
-            className="w-1/2 py-2 px-4 bg-violet-700 border border-gray-900  text-white rounded-l-lg  hover:bg-violet-900"
-          >
-            <p>Subscribe</p>
-            <span className="text-xs">via SMS</span>
-          </button>
-          <button
-            type="submit"
-            aria-disabled={pending}
             name="whatsapp-button"
-            className="w-1/2 py-2 px-4 bg-violet-700  border border-gray-900  text-white rounded-r-lg hover:bg-violet-900"
+            className="w-full py-2 px-4 bg-violet-700  border border-gray-900  text-white rounded-lg hover:bg-violet-900"
           >
             <p>Subscribe</p>
             <span className="text-xs">via WhatsApp</span>


### PR DESCRIPTION
@IObert @nokenwa 

For Singapore, we don't want to allow users to subscribe via SMS on https://partycookies.store/signup, instead just subscribe via WhatsApp. 